### PR TITLE
Support for NetBSD, DragonFlyBSD and OpenBSD

### DIFF
--- a/c_src/brg_endian.h
+++ b/c_src/brg_endian.h
@@ -39,7 +39,9 @@
 #define IS_LITTLE_ENDIAN   1234 /* byte 0 is least significant (i386) */
 
 /* Include files where endian defines and byteswap functions may reside */
-#if defined( __FreeBSD__ ) || defined( __OpenBSD__ ) || defined( __NetBSD__ )
+#if defined( __FreeBSD__ ) || defined( __OpenBSD__ ) || defined( __NetBSD__ ) || \
+    defined( __DragonFly__ )
+#  include <sys/types.h>
 #  include <sys/endian.h>
 #elif defined( BSD ) && ( BSD >= 199103 ) || defined( __APPLE__ ) || \
       defined( __CYGWIN32__ ) || defined( __DJGPP__ ) || defined( __osf__ )


### PR DESCRIPTION
There were 3 things that were fixed in this patch:

The endian detection header didn't contain all the possible machine
architecture definitions for AMD64, see
http://predef.sourceforge.net/prearch.html#sec3

DragonFlyBSD wasn't checked for as an OS along with the other BSDs

OpenBSD was exposing BSD symbols not defined by POSIX so rebar.config
now passes -D_POSIX_C_SOURCE to ensure these are hidden.
